### PR TITLE
feat: add a method to access wrapped rc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ fn hash_rc<T, H: Hasher>(rc: Rc<T>, state: &mut H) {
 /// assert_eq!(HashableRc::new(rc1.clone()),
 ///            HashableRc::new(rc1.clone()));
 /// ```
-#[derive(Debug, Eq)]
+#[derive(Debug)]
 pub struct HashableRc<T> {
     value: Rc<T>,
 }
@@ -166,6 +166,8 @@ impl <T> PartialEq for HashableRc<T> {
         Rc::ptr_eq(&self.value, &other.value)
     }
 }
+
+impl <T> Eq for HashableRc<T> {}
 
 /// A hashable wrapper around the 
 /// [`Weak<T>`](https://doc.rust-lang.org/std/rc/struct.Weak.html)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,11 @@ impl <T> HashableRc<T> {
         HashableRc {value}
     }
 
+    /// Returns a reference of the wrapped `Rc<T>`.
+    pub fn get(&self) -> &Rc<T> {
+        &self.value
+    }
+
     /// Returns a clone of the wrapped `Rc<T>` without consuming `self`.
     pub fn get_cloned(&self) -> Rc<T> {
         self.value.clone()


### PR DESCRIPTION
It adds a way to access to the wrapped `Rc<T>` without cloning one.